### PR TITLE
Update ReplikitAdapterException

### DIFF
--- a/src/adapters/Replikit.Adapters.Common/src/Exceptions/ReplikitAdapterException.cs
+++ b/src/adapters/Replikit.Adapters.Common/src/Exceptions/ReplikitAdapterException.cs
@@ -1,8 +1,10 @@
-﻿using Replikit.Abstractions.Common.Exceptions;
+using Replikit.Abstractions.Common.Exceptions;
 
 namespace Replikit.Adapters.Common.Exceptions;
 
 public class ReplikitAdapterException : ReplikitException
 {
     public ReplikitAdapterException(string? message) : base(message) { }
+    
+    public ReplikitAdapterException(string? message, Exception? innerException) : base(message, innerException) { }
 }


### PR DESCRIPTION
`ReplikitAdapterException` does not support `innerException` argument. This pull request fixes this.

As for the other exceptions, I'm not sure if they need `innerException` argument. But if there are exceptions that may affect the implementation of the adapter, then this argument must also be added to them. __Are there any such exceptions?__

__Changes:__
- Added constructor with `innerException` argument.
- Removed the first  character (__undefined__) in the `ReplikitAdapterException.cs` file.